### PR TITLE
rails halt and check_required_params

### DIFF
--- a/lib/api_hammer.rb
+++ b/lib/api_hammer.rb
@@ -1,1 +1,2 @@
 require 'api_hammer/version'
+require 'api_hammer/rails'

--- a/lib/api_hammer/check_required_params.rb
+++ b/lib/api_hammer/check_required_params.rb
@@ -1,0 +1,56 @@
+module ApiHammer::Rails
+  # halts with a 422 Unprocessable Entity and an appropriate error body if required params are missing 
+  #
+  # simple:
+  #
+  #     check_required_params(:id, :name)
+  #
+  # - params[:id] must be present
+  # - params[:name] must be present
+  #
+  # less simple:
+  #
+  #     check_required_params(:id, :person => [:name, :height], :lucky_numbers => Array)
+  #
+  # - params[:id] must be present
+  # - params[:person] must be present and be a hash
+  # - params[:person][:name] must be present
+  # - params[:person][:height] must be present
+  # - params[:lucky_numbers] must be present and be an array
+  def check_required_params(*checks)
+    errors = Hash.new { |h,k| h[k] = [] }
+    check_required_params_helper(checks, params, errors, [])
+    halt_unprocessable_entity(errors) if errors.any?
+  end
+
+  private
+  # helper 
+  def check_required_params_helper(check, subparams, errors, parents)
+    if subparams.nil?
+      errors[parents.join('#')] << "is required but was not provided"
+    elsif check
+      case check
+      when Array
+        check.each { |subcheck| check_required_params_helper(subcheck, subparams, errors, parents) }
+      when Hash
+        if subparams.is_a?(Hash)
+          check.each do |key, subcheck|
+            check_required_params_helper(subcheck, subparams[key], errors, parents + [key])
+          end
+        else
+          errors[parents.join('#')] << "must be a Hash"
+        end
+      when Class
+        unless subparams.is_a?(check)
+          errors[parents.join('#')] << "must be a #{check.name}"
+        end
+      else
+        if subparams.is_a?(Hash)
+          check_required_params_helper(nil, subparams[check], errors, parents + [check])
+        else
+          errors[parents.join('#')] << "must be a Hash"
+        end
+      end
+    end
+  end
+end

--- a/lib/api_hammer/halt.rb
+++ b/lib/api_hammer/halt.rb
@@ -1,0 +1,57 @@
+# the contents of this file are to let you halt a controller in its processing without having to have a 
+# return in the actual action. this lets helper methods which do things like parameter validation halt.
+#
+# it is desgined to function similarly to Sinatra's handling of throw(:halt), but is based around exceptions 
+# because rails doesn't catch anything, just rescues. 
+
+module ApiHammer
+  # an exception raised to stop processing an action and render the body given as the 'body' argument 
+  # (which is expected to be a JSON-able object)
+  class Halt < StandardError
+    def initialize(message, body, render_options={})
+      super(message)
+      @body = body
+      @render_options = render_options
+    end
+
+    attr_reader :body, :render_options
+  end
+end
+
+module ApiHammer::Rails
+  unless const_defined?(:HALT_INCLUDED)
+    HALT_INCLUDED = proc do |controller_class|
+      controller_class.send(:rescue_from, ApiHammer::Halt, :with => :handle_halt)
+    end
+    (@on_included ||= Set.new) << HALT_INCLUDED
+  end
+
+  # handle a raised ApiHammer::Halt or subclass and render it
+  def handle_halt(halt)
+    render_options = halt.render_options ? halt.render_options.dup : {}
+    # rocket pants does not have a render method, just render_json 
+    if respond_to?(:render_json, true)
+      render_json(halt.body || {}, render_options)
+    else
+      render_options[:json] = halt.body || {}
+      render(render_options)
+    end
+  end
+
+  def halt(status, body, render_options = {})
+    raise(ApiHammer::Halt.new(body.inspect, body, render_options.merge(:status => status)))
+  end
+
+  # 
+  def halt_error(status, errors, render_options = {})
+    halt(status, {'errors' => errors}, render_options)
+  end
+
+  def halt_bad_request(errors, render_options = {})
+    halt_error(400, errors, render_options)
+  end
+
+  def halt_unprocessable_entity(errors, render_options = {})
+    halt_error(422, errors, render_options)
+  end
+end

--- a/lib/api_hammer/rails.rb
+++ b/lib/api_hammer/rails.rb
@@ -1,0 +1,10 @@
+require 'api_hammer/halt'
+require 'api_hammer/check_required_params'
+
+module ApiHammer::Rails
+  def self.included(klass)
+    (@on_included || []).each do |included_proc|
+      included_proc.call(klass)
+    end
+  end
+end


### PR DESCRIPTION
this introduces some rather useful controller methods for those who are for whatever reason using rails for HTTP APIs 
- check_required_params
- halt
- halt_error
- halt_bad_request
- halt_unprocessable_entity
