### PR TITLE
trailing newline content type

### DIFF
--- a/lib/api_hammer/trailing_newline.rb
+++ b/lib/api_hammer/trailing_newline.rb
@@ -26,7 +26,8 @@ module ApiHammer
     end
     def call(env)
       status, headers, body = *@app.call(env)
-      if env['REQUEST_METHOD'].downcase != 'head' && ApiHammer::ContentTypeAttrs.new(env['CONTENT_TYPE']).text?
+      _, content_type = headers.detect { |(k,_)| k =~ /\Acontent.type\z/i }
+      if env['REQUEST_METHOD'].downcase != 'head' && ApiHammer::ContentTypeAttrs.new(content_type).text?
         body = TNLBodyProxy.new(body){}
         if headers["Content-Length"]
           headers["Content-Length"] = body.map(&Rack::Utils.method(:bytesize)).inject(0, &:+).to_s


### PR DESCRIPTION
oops. check the response content type, not request, for trailing newline of response.