### PR TITLE
log tailer 

### DIFF
--- a/lib/api_hammer/rails_request_logging.rb
+++ b/lib/api_hammer/rails_request_logging.rb
@@ -1,15 +1,23 @@
 require 'api_hammer'
 require 'active_support/log_subscriber'
 
-require 'rails/rack/log_tailer'
-# fix up this class to tail the log when the body is closed rather than when its own #call is done. 
-module Rails
-  module Rack
-    class LogTailer
-      def call(env)
-        status, headers, body = @app.call(env)
-        body_proxy = ::Rack::BodyProxy.new(body) { tail! }
-        [status, headers, body_proxy]
+begin
+  require 'rails/rack/log_tailer'
+  log_tailer_exists = true
+rescue LoadError
+  log_tailer_exists = false
+end
+
+if log_tailer_exists
+  # fix up this class to tail the log when the body is closed rather than when its own #call is done. 
+  module Rails
+    module Rack
+      class LogTailer
+        def call(env)
+          status, headers, body = @app.call(env)
+          body_proxy = ::Rack::BodyProxy.new(body) { tail! }
+          [status, headers, body_proxy]
+        end
       end
     end
   end


### PR DESCRIPTION
rails/rack/log_tailer was deprecated in rails 4 and is gone rails 5, so don't fix it up if it is gone.

this is as yet untested, need to confirm it actually behaves as expected before merge