### PR TITLE
bytesize

### DIFF
--- a/lib/api_hammer/request_logger.rb
+++ b/lib/api_hammer/request_logger.rb
@@ -101,7 +101,7 @@ module ApiHammer
         'response' => {
           'status' => status.to_s,
           'headers' => response_headers,
-          'length' => response_headers['Content-Length'] || response_body.to_enum.map(&::Rack::Utils.method(:bytesize)).inject(0, &:+),
+          'length' => response_headers['Content-Length'] || response_body.to_enum.map(&:bytesize).inject(0, &:+),
         }.reject { |k,v| v.nil? },
         'processing' => {
           'began_at' => began_at.utc.to_f,

--- a/lib/api_hammer/trailing_newline.rb
+++ b/lib/api_hammer/trailing_newline.rb
@@ -30,7 +30,7 @@ module ApiHammer
       if env['REQUEST_METHOD'].downcase != 'head' && ApiHammer::ContentTypeAttrs.new(content_type).text?
         body = TNLBodyProxy.new(body){}
         if headers["Content-Length"]
-          headers["Content-Length"] = body.map(&Rack::Utils.method(:bytesize)).inject(0, &:+).to_s
+          headers["Content-Length"] = body.map(&:bytesize).inject(0, &:+).to_s
         end
       end
       [status, headers, body]


### PR DESCRIPTION
rack drops bytesize util as ruby versions that don't have it on String are unsupported. so do we.