### PR TITLE
enable travis && specify which rubies we use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
-# we don't actually use travis, just wwtd 
-
+rvm:
+  - 2.0.0
+  - 2.2.4
 gemfile:
   - Gemfile_ar_3
   - Gemfile_ar_40


### PR DESCRIPTION
I enabled Travis-ci on my fork.

All tests pass for 2.0.0, 2.2.4 and currently present Gemfiles

https://travis-ci.org/mathieujobin/api_hammer/builds/130871139

@notEthan @ethnext 
