### PR TITLE
params for rails 5

### DIFF
--- a/lib/api_hammer/rails/check_required_params.rb
+++ b/lib/api_hammer/rails/check_required_params.rb
@@ -35,7 +35,7 @@ module ApiHammer::Rails
       when Array
         check.each { |subcheck| check_required_params_helper(subcheck, subparams, errors, parents) }
       when Hash
-        if subparams.is_a?(Hash)
+        if subparams.respond_to?(:to_h)
           check.each do |key, subcheck|
             check_required_params_helper(subcheck, subparams[key], errors, parents + [key])
           end


### PR DESCRIPTION
ActionController::Params no longer < Hash. don't want to check for that class directly, though (may not be loaded), so we will just check if params is hash-like enough to have #to_h

replaces #32 