### PR TITLE
Tests - rack, ruby 2.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ gemfile:
   - gemfiles/Gemfile_rack_2
 matrix:
   fast_finish: true
-  allow_failures:
-    - rvm: 2.3.1
-    - rvm: ruby-head
   exclude:
     - rvm: 2.0.0
       gemfile: gemfiles/Gemfile_rack_2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,22 @@
 rvm:
-  - 2.0.0-p353
-  - 2.2.4
+  - 2.0.0
+  - 2.2.5
+  - 2.3.1
+gemfile:
+  - gemfiles/Gemfile_rack_1
+  - gemfiles/Gemfile_rack_2
+matrix:
+  fast_finish: true
+  allow_failures:
+    - rvm: 2.3.1
+    - rvm: ruby-head
+  exclude:
+    - rvm: 2.0.0
+      gemfile: gemfiles/Gemfile_rack_2
+    - rvm: 2.1.10
+      gemfile: gemfiles/Gemfile_rack_2
+    - rvm: 2.3.1
+      gemfile: gemfiles/Gemfile_rack_1
+    - rvm: ruby-head
+      gemfile: gemfiles/Gemfile_rack_1
 script: rake test

--- a/api_hammer.gemspec
+++ b/api_hammer.gemspec
@@ -35,5 +35,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'activesupport'
-  spec.add_development_dependency 'sqlite3'
 end

--- a/gemfiles/Gemfile_rack_1
+++ b/gemfiles/Gemfile_rack_1
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'byebug'
+gem 'wwtd'
+
+gem 'rack', '< 2'
+gem 'activesupport', '< 5'

--- a/gemfiles/Gemfile_rack_2
+++ b/gemfiles/Gemfile_rack_2
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'byebug'
+gem 'wwtd'
+
+gem 'rack', '>= 2'
+gem 'activesupport', '>= 5'

--- a/test/public_instance_exec_test.rb
+++ b/test/public_instance_exec_test.rb
@@ -23,10 +23,10 @@ describe '#public_instance_exec' do
     assert_equal(:public_exec, foo.public_instance_exec(:public_exec) { |arg| public_method(arg) })
     regularex = (foo.protected_method rescue $!)
     ex = assert_raises(regularex.class) { foo.public_instance_exec(:protected_exec) { |arg| protected_method(arg) } }
-    assert_equal(regularex.message, ex.message)
+    assert_includes(regularex.message, ex.message)
     regularex = (foo.private_method rescue $!)
     ex = assert_raises(regularex.class) { foo.public_instance_exec(:private_exec) { |arg| private_method(arg) } }
-    assert_equal(regularex.message, ex.message)
+    assert_includes(regularex.message, ex.message)
   end
 end
 describe '#public_instance_eval' do
@@ -35,9 +35,9 @@ describe '#public_instance_eval' do
     assert_equal(:public, foo.public_instance_eval { public_method })
     regularex = (foo.protected_method rescue $!)
     ex = assert_raises(regularex.class) { foo.public_instance_eval { protected_method } }
-    assert_equal(regularex.message, ex.message)
+    assert_includes(regularex.message, ex.message)
     regularex = (foo.private_method rescue $!)
     ex = assert_raises(regularex.class) { foo.public_instance_eval { private_method } }
-    assert_equal(regularex.message, ex.message)
+    assert_includes(regularex.message, ex.message)
   end
 end


### PR DESCRIPTION
fixes 2.3.1 issue with an error message. replaces #55; drops ruby-head (moving target) and 2.1 (I don't care about 2.1) 