### PR TITLE
Display 4xx errors on rollbar if available

### DIFF
--- a/lib/api_hammer/halt_methods.rb
+++ b/lib/api_hammer/halt_methods.rb
@@ -31,7 +31,7 @@ module ApiHammer
         end
       end
       body['error_message'] = error_message if error_message
-      if defined?(Rollbar) and status != 404
+      if Object.const_defined?(:Rollbar) and status != 404
         Rollbar.debug "Service halted with status #{status}", status: status, body: body, halt_options: halt_options
       end
       halt(status, body, halt_options)

--- a/lib/api_hammer/halt_methods.rb
+++ b/lib/api_hammer/halt_methods.rb
@@ -31,6 +31,9 @@ module ApiHammer
         end
       end
       body['error_message'] = error_message if error_message
+      if defined?(Rollbar) and status != 404
+        Rollbar.debug "Service halted with status #{status}", status: status, body: body, halt_options: halt_options
+      end
       halt(status, body, halt_options)
     end
 


### PR DESCRIPTION
@notEthan when parsing through charles log, all the 422 is lacking info to troubleshoot
it would help if they would be easily accessible on rollbar.

i dont think 404 are useful, so I am filtering them
other 4xx codes are very unfrequent, so I think its good to keep

