### PR TITLE
make logger 'duration' field monotonic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 rvm:
-  - 2.0.0
-  - 2.2.5
-  - 2.3.1
+  - 2.2.10
+  - 2.3.8
+  - 2.6.1
 gemfile:
   - gemfiles/Gemfile_rack_1
   - gemfiles/Gemfile_rack_2

--- a/lib/api_hammer/faraday/request_logger.rb
+++ b/lib/api_hammer/faraday/request_logger.rb
@@ -79,8 +79,8 @@ module ApiHammer
 
           json_data = JSON.generate(data)
           dolog = proc do
-            now_s = now.strftime('%Y-%m-%d %H:%M:%S %Z')
-            @logger.info "#{bold(intense_magenta('>'))} #{status_s(status)} : #{bold(intense_magenta(request_env[:method].to_s.upcase))} #{intense_magenta(request_env[:url].normalize.to_s)} @ #{intense_magenta(now_s)}"
+            began_s = began_at.strftime('%Y-%m-%d %H:%M:%S %Z')
+            @logger.info "#{bold(intense_magenta('>'))} #{status_s(status)} : #{bold(intense_magenta(request_env[:method].to_s.upcase))} #{intense_magenta(request_env[:url].normalize.to_s)} @ #{intense_magenta(began_s)}"
             @logger.info json_data
           end
 

--- a/lib/api_hammer/faraday/request_logger.rb
+++ b/lib/api_hammer/faraday/request_logger.rb
@@ -29,6 +29,7 @@ module ApiHammer
 
       def call(request_env)
         began_at = Time.now
+        began_ns = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)
 
         log_tags = Thread.current[:activesupport_tagged_logging_tags]
         saved_log_tags = log_tags.dup if log_tags && log_tags.any?
@@ -36,7 +37,7 @@ module ApiHammer
         request_body = request_env[:body].dup if request_env[:body]
 
         @app.call(request_env).on_complete do |response_env|
-          now = Time.now
+          now_ns = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)
           status = response_env[:status]
 
           if log_bodies(status)
@@ -72,7 +73,7 @@ module ApiHammer
             }.reject{|k,v| v.nil? },
             'processing' => {
               'began_at' => began_at.utc.to_f,
-              'duration' => now - began_at,
+              'duration' => (now_ns - began_ns) * 1e-9,
               'activesupport_tagged_logging_tags' => log_tags,
             }.reject{|k,v| v.nil? },
           }

--- a/lib/api_hammer/request_logger.rb
+++ b/lib/api_hammer/request_logger.rb
@@ -156,8 +156,8 @@ module ApiHammer
       Thread.current['request_logger.info'] = nil
       json_data = JSON.dump(data)
       dolog = proc do
-        now_s = now.strftime('%Y-%m-%d %H:%M:%S %Z')
-        @logger.info "#{bold(intense_cyan('<'))} #{status_s(status)} : #{bold(intense_cyan(request.request_method))} #{intense_cyan(request_uri.normalize)} @ #{intense_cyan(now_s)}"
+        began_s = began_at.strftime('%Y-%m-%d %H:%M:%S %Z')
+        @logger.info "#{bold(intense_cyan('<'))} #{status_s(status)} : #{bold(intense_cyan(request.request_method))} #{intense_cyan(request_uri.normalize)} @ #{intense_cyan(began_s)}"
         @logger.info json_data
       end
       # do the logging with tags that applied to the request if appropriate 


### PR DESCRIPTION
system clock change should not affect the calculated duration. 

I'm also logging the info line with the request start time rather than the end time.