### PR TITLE
bugfix for request logger tags

### DIFF
--- a/lib/api_hammer/request_logger.rb
+++ b/lib/api_hammer/request_logger.rb
@@ -61,8 +61,9 @@ module ApiHammer
       request_body = env["rack.input"].read
       env["rack.input"].rewind
 
-      log_tags = Thread.current[:activesupport_tagged_logging_tags]
-      log_tags = log_tags.dup if log_tags && log_tags.any?
+      if @logger && @logger.formatter.respond_to?(:current_tags)
+        log_tags = @logger.formatter.current_tags.dup
+      end
 
       request = Rack::Request.new(env)
       request_uri = Addressable::URI.new(


### PR DESCRIPTION
use the proper interface for tagged logger's current tags, not an undocumented Thread.local variable