### PR TITLE
drop ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 rvm:
-  - 2.0.0
-  - 2.2.5
-  - 2.3.1
+  - 2.2.10
+  - 2.3.8
+  - 2.6.1
 gemfile:
   - gemfiles/Gemfile_rack_1
   - gemfiles/Gemfile_rack_2


### PR DESCRIPTION
drop long-EOL ruby 2.0.0. versions will be 2.2 min up to the latest with one in between.
